### PR TITLE
Release 4.5.5

### DIFF
--- a/.github/workflows/cache_rust.yml
+++ b/.github/workflows/cache_rust.yml
@@ -1,10 +1,10 @@
 name: Cache Rust dependencies
 
 on:
-  push:
-    branches: [ "*" ]
   pull_request:
     branches: [ "*" ]
+  push:
+    branches: [ "main" ]
 
 
 jobs:

--- a/.github/workflows/realms.yml
+++ b/.github/workflows/realms.yml
@@ -3,6 +3,8 @@ name: Rust
 on:
   pull_request:
     branches: [ "*" ]
+  push:
+    branches: [ "main" ]
 
 env:
   CARGO_TERM_COLOR: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,3 +88,7 @@ Non-breaking changes:
 - Fix texture loading to support RGBA
 - Create example 5: texture
 - Add formatting checks to CI workflows
+
+## 3.5.5 -> 4.5.5 (major, breaking)
+
+- Rename `RectangleShape` -> `Rectangle`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -93,3 +93,4 @@ Non-breaking changes:
 
 - Rename `RectangleShape` -> `Rectangle`
 - Rename `TriangleShape` -> `Triangle`
+- Rename `shape2d_shader` -> `shader_2d`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -92,3 +92,4 @@ Non-breaking changes:
 ## 3.5.5 -> 4.5.5 (major, breaking)
 
 - Rename `RectangleShape` -> `Rectangle`
+- Rename `TriangleShape` -> `Triangle`

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "realms"
-version = "3.5.5"
+version = "4.5.5"
 description = "A powerful and lightweight graphics library for making Rust games"
 homepage = "https://github.com/dylanopen/realms"
 repository = "https://github.com/dylanopen/realms"

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -225,25 +225,25 @@ impl TriangleShape {
     }
 }
 
-/// The `RectangleShape` struct represents any 3 points in the 2d plane. Each
+/// The `Rectangle` struct represents any 3 points in the 2d plane. Each
 /// point (vertex) is made up of:
 /// - 2 position components (x, y)
 /// - 3 color components (r, g, b)
 ///
-/// There are many different `new` methods for a `TriangleShape`, each providing
-/// an easy way to create a certain type of triangle.
-/// For examples, please see the different functions that `TriangleShape`
+/// There are many different `new` methods for a `Rectangle`, each providing
+/// an easy way to create a certain type of rectangle.
+/// For examples, please see the different functions that `Rectangle`
 /// implements.
 #[non_exhaustive]
 pub struct Rectangle {
-    /// Stores the `VertexBuffer` that represents the triangle.
+    /// Stores the `VertexBuffer` that represents the rectangle.
     /// See the documentation for `VertexBuffer` for more info.
-    /// The `TriangleShape::draw` method will call `vertex_buffer.draw`.
+    /// The `Rectangle::draw` method will call `vertex_buffer.draw`.
     vertex_buffer: VertexBuffer,
 }
 
 impl Rectangle {
-    /// Create a new `TriangleShape`from a list of 15 `f32`s. The list is a set
+    /// Create a new `Rectangle` from a list of 15 `f32`s. The list is a set
     /// of 3 vertices, each containing two components:
     /// - a *position* made up of `2` `f32`s (x, y)
     /// - a *color* made up of `3` `f32`s (r, g, b)
@@ -252,14 +252,15 @@ impl Rectangle {
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let triangle = TriangleShape::new(&[
+    /// let rectangle = Rectangle::new(&[
     ///     -0.5, -0.5, 1.0, 0.0, 0.0,
     ///      0.5, -0.5, 0.0, 1.0, 0.0,
+    ///      0.5,  0.5, 1.0, 1.0, 1.0,
     ///     -0.5,  0.5, 0.0, 0.0, 1.0,
     /// ]);
     /// while w.is_running() {
     ///     ...
-    ///     triangle.draw(&shader);
+    ///     rectangle.draw(&shader);
     /// }
     /// ```
     #[inline]
@@ -270,7 +271,7 @@ impl Rectangle {
         Rectangle { vertex_buffer }
     }
 
-    /// Create a new `RectangleShape` from a list of 8 `f32`s and a color for
+    /// Create a new `Rectangle` from a list of 8 `f32`s and a color for
     /// the entire rectangle. The list is a set of 4 vertices, each containing
     /// one component:
     /// - a *position* made up of `2` `f32`s (x, y)
@@ -278,13 +279,13 @@ impl Rectangle {
     /// As the name implies, this function will create a new rectangle with a
     /// single, solid color for the entire rectangle. If you need to interpolate
     /// (blend) between different colors and have different colors for each
-    /// vertex, use the `RectangleShape::new` function.
+    /// vertex, use the `Rectangle::new` function.
     ///
     /// ## Example usage
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let rectangle = RectangleShape::new_solid(&[
+    /// let rectangle = Rectangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
     ///      0.5,  0.5,
@@ -308,7 +309,7 @@ impl Rectangle {
         ])
     }
 
-    /// Create a new `RectangleShape` from an `x` position, `y` position,
+    /// Create a new `Rectangle` from an `x` position, `y` position,
     /// `width` and `height`.
     ///
     /// The coordinates for the rectangle are calculated like this:
@@ -331,7 +332,7 @@ impl Rectangle {
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let rectangle = RectangleShape::new_flat(
+    /// let rectangle = Rectangle::new_flat(
     ///     -0.5, -0.5, 1.0, 1.0,
     ///     Color::new(63, 191, 91)
     /// );
@@ -361,7 +362,7 @@ impl Rectangle {
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let rectangle = RectangleShape::new_solid(&[
+    /// let rectangle = Rectangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
     ///      0.5,  0.5,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -66,29 +66,25 @@ pub fn shape2d_shader() -> ShaderProgram {
     .unwrap()
 }
 
-/// The `TriangleShape` struct represents any 3 points in the 2d plane. Each
+/// The `Triangle` struct represents any 3 points in the 2d plane. Each
 /// point (vertex) is made up of:
 /// - 2 position components (x, y)
 /// - 3 color components (r, g, b)
 ///
-/// There are many different `new` methods for a `TriangleShape`, each providing
+/// There are many different `new` methods for a `Triangle`, each providing
 /// an easy way to create a certain type of triangle.
-/// For examples, please see the different functions that `TriangleShape`
+/// For examples, please see the different functions that `Triangle`
 /// implements.
-#[expect(
-    clippy::module_name_repetitions,
-    reason = "Will be renamed to Triangle in the next major release."
-)]
 #[non_exhaustive]
-pub struct TriangleShape {
+pub struct Triangle {
     /// Stores the `VertexBuffer` that represents the triangle.
     /// See the documentation for `VertexBuffer` for more info.
-    /// The `TriangleShape::draw` method will call `vertex_buffer.draw`.
+    /// The `Triangle::draw` method will call `vertex_buffer.draw`.
     vertex_buffer: VertexBuffer,
 }
 
-impl TriangleShape {
-    /// Create a new `TriangleShape`from a list of 15 `f32`s. The list is a set
+impl Triangle {
+    /// Create a new `Triangle`from a list of 15 `f32`s. The list is a set
     /// of 3 vertices, each containing two components:
     /// - a *position* made up of `2` `f32`s (x, y)
     /// - a *color* made up of `3` `f32`s (r, g, b)
@@ -97,7 +93,7 @@ impl TriangleShape {
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let triangle = TriangleShape::new(&[
+    /// let triangle = Triangle::new(&[
     ///     -0.5, -0.5, 1.0, 0.0, 0.0,
     ///      0.5, -0.5, 0.0, 1.0, 0.0,
     ///     -0.5,  0.5, 0.0, 0.0, 1.0,
@@ -109,13 +105,13 @@ impl TriangleShape {
     /// ```
     #[inline]
     #[must_use]
-    pub fn new(vertices: &[f32; 15]) -> TriangleShape {
+    pub fn new(vertices: &[f32; 15]) -> Triangle {
         let vertex_buffer = VertexBuffer::new(vertices, &[0, 1, 2]);
         vertex_buffer.set_layout(&[2_i32, 3_i32]);
-        TriangleShape { vertex_buffer }
+        Triangle { vertex_buffer }
     }
 
-    /// Create a new `TriangleShape` from a list of 6 `f32`s and a color for the
+    /// Create a new `Triangle` from a list of 6 `f32`s and a color for the
     /// entire triangle. The list is a set of 3 vertices, each containing one
     /// component:
     /// - a *position* made up of `2` `f32`s (x, y)
@@ -123,13 +119,13 @@ impl TriangleShape {
     /// As the name implies, this function will create a new triangle with a
     /// single, solid color for the entire triangle. If you need to interpolate
     /// (blend) between different colors and have different colors for each
-    /// vertex, use the `TriangleShape::new` function.
+    /// vertex, use the `Triangle::new` function.
     ///
     /// ## Example usage
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let triangle = TriangleShape::new_solid(&[
+    /// let triangle = Triangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
     ///     -0.5,  0.5,
@@ -142,16 +138,16 @@ impl TriangleShape {
     #[inline]
     #[must_use]
     #[rustfmt::skip]
-    pub fn new_solid(vertices: &[f32; 6], color: &Color) -> TriangleShape {
+    pub fn new_solid(vertices: &[f32; 6], color: &Color) -> Triangle {
         let (r, g, b, _) = color.gl();
-        TriangleShape::new(&[
+        Triangle::new(&[
             vertices[0], vertices[1], r, g, b,
             vertices[2], vertices[3], r, g, b,
             vertices[4], vertices[5], r, g, b,
         ])
     }
 
-    /// Create a new `TriangleShape` as an isosceles triangle with a flat base.
+    /// Create a new `Triangle` as an isosceles triangle with a flat base.
     /// Isosceles triangles have two sides the same.
     /// The coordinates for the isosceles triangle are calculated like this:
     ///
@@ -173,7 +169,7 @@ impl TriangleShape {
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let triangle = TriangleShape::new_flat_isosceles(
+    /// let triangle = Triangle::new_flat_isosceles(
     ///     -0.5, -0.5, 1.0, 1.0,
     ///     Color::new(63, 191, 91)
     /// );
@@ -184,14 +180,8 @@ impl TriangleShape {
     /// ```
     #[inline]
     #[must_use]
-    pub fn new_flat_isosceles(
-        x: f32,
-        y: f32,
-        width: f32,
-        height: f32,
-        color: &Color,
-    ) -> TriangleShape {
-        TriangleShape::new_solid(
+    pub fn new_flat_isosceles(x: f32, y: f32, width: f32, height: f32, color: &Color) -> Triangle {
+        Triangle::new_solid(
             &[x, y, x + width, y, width.mul_add(0.5, x), y + height],
             color,
         )
@@ -209,7 +199,7 @@ impl TriangleShape {
     ///
     /// ``` rust
     /// let shader = shape2d_shader();
-    /// let triangle = TriangleShape::new_solid(&[
+    /// let triangle = Triangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
     ///     -0.5,  0.5,

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -234,19 +234,15 @@ impl TriangleShape {
 /// an easy way to create a certain type of triangle.
 /// For examples, please see the different functions that `TriangleShape`
 /// implements.
-#[expect(
-    clippy::module_name_repetitions,
-    reason = "Will be renamed to Rectangle in the next major release."
-)]
 #[non_exhaustive]
-pub struct RectangleShape {
+pub struct Rectangle {
     /// Stores the `VertexBuffer` that represents the triangle.
     /// See the documentation for `VertexBuffer` for more info.
     /// The `TriangleShape::draw` method will call `vertex_buffer.draw`.
     vertex_buffer: VertexBuffer,
 }
 
-impl RectangleShape {
+impl Rectangle {
     /// Create a new `TriangleShape`from a list of 15 `f32`s. The list is a set
     /// of 3 vertices, each containing two components:
     /// - a *position* made up of `2` `f32`s (x, y)
@@ -268,10 +264,10 @@ impl RectangleShape {
     /// ```
     #[inline]
     #[must_use]
-    pub fn new(vertices: &[f32; 20]) -> RectangleShape {
+    pub fn new(vertices: &[f32; 20]) -> Rectangle {
         let vertex_buffer = VertexBuffer::new(vertices, &[0, 1, 2, 2, 3, 0]);
         vertex_buffer.set_layout(&[2_i32, 3_i32]);
-        RectangleShape { vertex_buffer }
+        Rectangle { vertex_buffer }
     }
 
     /// Create a new `RectangleShape` from a list of 8 `f32`s and a color for
@@ -302,9 +298,9 @@ impl RectangleShape {
     #[inline]
     #[must_use]
     #[rustfmt::skip]
-    pub fn new_solid(vertices: &[f32; 8], color: &Color) -> RectangleShape {
+    pub fn new_solid(vertices: &[f32; 8], color: &Color) -> Rectangle {
         let (r, g, b, _) = color.gl();
-        RectangleShape::new(&[
+        Rectangle::new(&[
             vertices[0], vertices[1], r, g, b,
             vertices[2], vertices[3], r, g, b,
             vertices[4], vertices[5], r, g, b,
@@ -346,8 +342,8 @@ impl RectangleShape {
     /// ```
     #[inline]
     #[must_use]
-    pub fn new_flat(x: f32, y: f32, width: f32, height: f32, color: &Color) -> RectangleShape {
-        RectangleShape::new_solid(
+    pub fn new_flat(x: f32, y: f32, width: f32, height: f32, color: &Color) -> Rectangle {
+        Rectangle::new_solid(
             &[x, y, x + width, y, x + width, y + height, x, y + height],
             color,
         )

--- a/src/shape.rs
+++ b/src/shape.rs
@@ -22,7 +22,7 @@ use crate::vertex::VertexBuffer;
 /// ## Example usage
 ///
 /// ``` rust
-/// let shape2d_program = shape2d_shader();
+/// let shape2d_program = shader_2d();
 /// let triangle = Triangle::new(...);
 /// while w.is_running() {
 ///     ...
@@ -44,13 +44,9 @@ use crate::vertex::VertexBuffer;
     clippy::unwrap_used,
     reason = "This should never panic as it is compile-time included. However, it is possible, see the doc-comment."
 )]
-#[expect(
-    clippy::module_name_repetitions,
-    reason = "Will be renamed to shader_2d in the next major release."
-)]
 #[inline]
 #[must_use]
-pub fn shape2d_shader() -> ShaderProgram {
+pub fn shader_2d() -> ShaderProgram {
     ShaderProgram::new(vec![
         Shader::load_str(
             ShaderType::Vertex,
@@ -92,7 +88,7 @@ impl Triangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let triangle = Triangle::new(&[
     ///     -0.5, -0.5, 1.0, 0.0, 0.0,
     ///      0.5, -0.5, 0.0, 1.0, 0.0,
@@ -124,7 +120,7 @@ impl Triangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let triangle = Triangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
@@ -168,7 +164,7 @@ impl Triangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let triangle = Triangle::new_flat_isosceles(
     ///     -0.5, -0.5, 1.0, 1.0,
     ///     Color::new(63, 191, 91)
@@ -189,7 +185,7 @@ impl Triangle {
 
     /// Draw the triangle to the screen.
     /// You **must** pass in a reference to the shader program returned by the
-    /// `shape2d_shader()` function, or a compatible shader program, or else
+    /// `shader_2d()` function, or a compatible shader program, or else
     /// this method will fail silently.
     ///
     /// This method currently simply calls the `draw` method of the
@@ -198,7 +194,7 @@ impl Triangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let triangle = Triangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
@@ -241,7 +237,7 @@ impl Rectangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let rectangle = Rectangle::new(&[
     ///     -0.5, -0.5, 1.0, 0.0, 0.0,
     ///      0.5, -0.5, 0.0, 1.0, 0.0,
@@ -274,7 +270,7 @@ impl Rectangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let rectangle = Rectangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,
@@ -321,7 +317,7 @@ impl Rectangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let rectangle = Rectangle::new_flat(
     ///     -0.5, -0.5, 1.0, 1.0,
     ///     Color::new(63, 191, 91)
@@ -342,7 +338,7 @@ impl Rectangle {
 
     /// Draw the rectangle to the screen.
     /// You **must** pass in a reference to the shader program returned by the
-    /// `shape2d_shader()` function, or a compatible shader program, or else
+    /// `shader_2d()` function, or a compatible shader program, or else
     /// this method will fail silently.
     ///
     /// This method currently simply calls the `draw` method of the
@@ -351,7 +347,7 @@ impl Rectangle {
     /// ## Example usage
     ///
     /// ``` rust
-    /// let shader = shape2d_shader();
+    /// let shader = shader_2d();
     /// let rectangle = Rectangle::new_solid(&[
     ///     -0.5, -0.5,
     ///      0.5, -0.5,


### PR DESCRIPTION
- Rename `RectangleShape` -> `Rectangle`
- Rename `TriangleShape` -> `Triangle`
- Rename `shape2d_shader` -> `shader_2d`